### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "core-util-is": "^1.0.2",
-    "env-to-code": "^1.0.4",
     "err-object": "^5.1.4",
     "has-own-prop": "^2.0.0",
     "is-absolute": "^1.0.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during the test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?